### PR TITLE
adding logout option, login required for personal pages

### DIFF
--- a/ultimatejob/urls.py
+++ b/ultimatejob/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('signup/', views.sign_up, name="signup"),
     path('personal_area/', views.personal_area, name="personal_area"),
     path('sign_in/', views.sign_in_view, name="sign_in"),
-    path('available_jobs/', views.available_jobs, name="available_jobs")
+    path('available_jobs/', views.available_jobs, name="available_jobs"),
+    path('logout/', views.logout_view, name="logout")
 
 ]

--- a/ultimatejobweb/templates/base_html.html
+++ b/ultimatejobweb/templates/base_html.html
@@ -41,6 +41,11 @@
             <li class="page-item">
                 <a href=" /available_jobs" class="page-link">available jobs for you</a>
             </li>
+			<li>
+				<form class= "logout-link" method="post" action=" /logout/">
+					{% csrf_token %}
+					<button type="submit">Logout</button>
+				</form>
         </ul>
 	
 	

--- a/ultimatejobweb/templates/sign_in.html
+++ b/ultimatejobweb/templates/sign_in.html
@@ -19,7 +19,7 @@
  <form method="post">
   {% csrf_token %}
   {{ form.as_p }}
-  <button type="submit">Log In</button>
+  <input type="submit" value="Login">
 </form>
 
 </div>

--- a/ultimatejobweb/views.py
+++ b/ultimatejobweb/views.py
@@ -1,7 +1,8 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth.forms import AuthenticationForm
-from django.shortcuts import redirect
 from .forms import SignUpFroms
+from django.contrib.auth import login, logout
+from django.contrib.auth.decorators import login_required
 
 
 def homepage(request):
@@ -20,15 +21,25 @@ def sign_in_view(request):
     if request.method == 'POST':
         form = AuthenticationForm(data=request.POST)
         if form.is_valid():
+            user = form.get_user()
+            login(request, user)
             return redirect('personal_area')
     else:
         form = AuthenticationForm()
     return render(request, r"sign_in.html", {'form': form})
 
 
+@login_required(login_url="/sign_in")
 def personal_area(request):
     return render(request, r"personal_area.html")
 
 
+@login_required(login_url="/sign_in")
 def available_jobs(request):
     return render(request, r"available_jobs.html")
+
+
+def logout_view(request):
+    if request.method == 'POST':
+        logout(request)
+        return redirect('sign_in')


### PR DESCRIPTION
Added logout option, and now there only users who are logged in can go to "personal area" and "available jobs" pages.
If someone who is not logged in tries to access these pages- he is redirected to the sign in page. 
only after he puts in correct username and password- he is redirected to the personal area.

fixes issue #66 