### PR TITLE
adding scroller to table in available jobs page using CSS

### DIFF
--- a/ultimatejobweb/templates/base_html.html
+++ b/ultimatejobweb/templates/base_html.html
@@ -26,6 +26,18 @@
 		height: 120px;
 		float:left;
 		}
+
+        table{
+            width: 100%;
+            display: block;
+            position: relative;
+            table-layout: fixed;
+            border-collapse: collapse;
+            overflow-y: auto;
+            height: 200px;
+
+        }
+
 	</style>
 
 </head>


### PR DESCRIPTION
While checking the actual site with the long list of job offers, we saw that some of the results appeared on top of the footer of the website, so i added a scroller to the table that shows the job offers, and that way the table will be catch the same size of the screen all the time.